### PR TITLE
Fixed generating translations on windows

### DIFF
--- a/src/Generate/Controller.php
+++ b/src/Generate/Controller.php
@@ -60,7 +60,7 @@ class Controller extends ClassGenerator {
                 resource_path('views/admin/layout/sidebar.blade.php'),
                 '|url\(\'admin\/'.$this->resource.'\'\)|',
                 "{{-- Do not delete me :) I'm used for auto-generation menu items --}}",
-                "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ url('admin/".$this->resource."') }}\"><i class=\"".$icon."\"></i> <span class=\"nav-link-text\">{{ trans('admin.".$this->modelLangFormat.".title') }}</span></a></li>\n            {{-- Do not delete me :) I'm used for auto-generation menu items --}}"
+                "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ url('admin/".$this->resource."') }}\"><i class=\"".$icon."\"></i> <span class=\"nav-link-text\">{{ trans('admin.".$this->modelLangFormat.".title') }}</span></a></li>".PHP_EOL."           {{-- Do not delete me :) I'm used for auto-generation menu items --}}"
             )) {
                 $this->info('Updating sidebar');
             }

--- a/src/Generate/FileAppender.php
+++ b/src/Generate/FileAppender.php
@@ -51,7 +51,7 @@ abstract class FileAppender extends Command {
      * @param string $defaultContent content that will be used to populated with newly created file (in case it does not already exists)
      * @return bool
      */
-    protected function appendIfNotAlreadyAppended($path, $content, $defaultContent = "<?php\n\n")
+    protected function appendIfNotAlreadyAppended($path, $content, $defaultContent = "<?php".PHP_EOL.PHP_EOL)
     {
         if (!$this->files->exists($path)) {
             $this->makeDirectory($path);
@@ -74,7 +74,7 @@ abstract class FileAppender extends Command {
      * @param string $defaultContent content that will be used to populated with newly created file (in case it does not already exists)
      * @return bool
      */
-    protected function replaceIfNotPresent($path, $search, $replace, $defaultContent = "<?php\n\n")
+    protected function replaceIfNotPresent($path, $search, $replace, $defaultContent = "<?php".PHP_EOL.PHP_EOL)
     {
         if (!$this->files->exists($path)) {
             $this->makeDirectory($path);

--- a/src/Generate/Lang.php
+++ b/src/Generate/Lang.php
@@ -52,7 +52,7 @@ class Lang extends FileAppender {
 
         // TODO name-spaced model names should be probably inserted as a sub-array in a translation file..
 
-        if ($this->replaceIfNotPresent(resource_path('lang/'.$locale.'/admin.php'),  "// Do not delete me :) I'm used for auto-generation\n",$this->buildClass()."\n", "<?php\n\nreturn [\n    // Do not delete me :) I'm used for auto-generation\n];")){
+        if ($this->replaceIfNotPresent(resource_path('lang/'.$locale.'/admin.php'),  "// Do not delete me :) I'm used for auto-generation".PHP_EOL,$this->buildClass().PHP_EOL, "<?php".PHP_EOL.PHP_EOL."return [".PHP_EOL."    // Do not delete me :) I'm used for auto-generation".PHP_EOL."];")){
             $this->info('Appending translations finished');
         }
     }

--- a/src/Generate/Routes.php
+++ b/src/Generate/Routes.php
@@ -40,7 +40,7 @@ class Routes extends FileAppender {
             $this->view = 'templates.'.$template.'.routes';
         }
 
-        if ($this->appendIfNotAlreadyAppended(base_path('routes/web.php'), "\n\n".$this->buildClass())){
+        if ($this->appendIfNotAlreadyAppended(base_path('routes/web.php'), PHP_EOL.PHP_EOL.$this->buildClass())){
             $this->info('Appending routes finished');
         }
     }

--- a/src/Generate/ViewForm.php
+++ b/src/Generate/ViewForm.php
@@ -138,10 +138,10 @@ class ViewForm extends ViewGenerator {
 		$indexJsPath = resource_path('assets/admin/js/'.$this->modelJSName.'/index.js');
 		$bootstrapJsPath = resource_path('assets/admin/js/index.js');
 
-		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Form';\n")){
+		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Form';".PHP_EOL)){
 			$this->info('Appending Form to '.$indexJsPath.' finished');
 		};
-		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './".$this->modelJSName."';\n")){
+		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './".$this->modelJSName."';".PHP_EOL)){
 			$this->info('Appending Form to '.$bootstrapJsPath.' finished');
 		};
     }

--- a/src/Generate/ViewFullForm.php
+++ b/src/Generate/ViewFullForm.php
@@ -129,10 +129,10 @@ class ViewFullForm extends ViewGenerator {
 			$this->makeDirectory($indexJsPath);
 		}
 
-		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Form';\n")){
+		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Form';".PHP_EOL)){
 			$this->info('Appending Form to '.$indexJsPath.' finished');
 		};
-		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './". $this->formJsRelativePath ."';\n")){
+		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './". $this->formJsRelativePath ."';".PHP_EOL)){
 			$this->info('Appending '.$this->formJsRelativePath.'/index.js to '.$bootstrapJsPath.' finished');
 		};
 

--- a/src/Generate/ViewIndex.php
+++ b/src/Generate/ViewIndex.php
@@ -86,10 +86,10 @@ class ViewIndex extends ViewGenerator {
         }
 
 
-		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Listing';\n")){
+		if ($this->appendIfNotAlreadyAppended($indexJsPath, "import './Listing';".PHP_EOL)){
 			$this->info('Appending Listing to '.$indexJsPath.' finished');
 		}
-		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './". $this->modelJSName ."';\n")){
+		if ($this->appendIfNotAlreadyAppended($bootstrapJsPath, "import './". $this->modelJSName ."';".PHP_EOL)){
 			$this->info('Appending '.$this->modelJSName.'/index.js to '.$bootstrapJsPath.' finished');
 		};
     }


### PR DESCRIPTION
Used _PHP_EOL_ constant instead of _\n_ when generating translations for model to extend portability to windows.