### PR TITLE
datepicker fix

### DIFF
--- a/src/Generate/Traits/Columns.php
+++ b/src/Generate/Traits/Columns.php
@@ -105,12 +105,12 @@ trait Columns {
                 case 'datetime':
                     $serverStoreRules->push('\'date\'');
                     $serverUpdateRules->push('\'date\'');
-                    $frontendRules->push('date_format:YYYY-MM-DD HH:mm:ss');
+                    $frontendRules->push('date_format:yyyy-MM-dd HH:mm:ss');
                     break;
                 case 'date':
                     $serverStoreRules->push('\'date\'');
                     $serverUpdateRules->push('\'date\'');
-                    $frontendRules->push('date_format:YYYY-MM-DD HH:mm:ss');
+                    $frontendRules->push('date_format:yyyy-MM-dd HH:mm:ss');
                     break;
                 case 'time':
                     $serverStoreRules->push('\'date_format:H:i:s\'');


### PR DESCRIPTION
fix for error message "[Vue warn]: Error in callback for watcher "form.published_at": "RangeError: `options.awareOfUnicodeTokens` must be set to `true` to use `YYYY` token;"